### PR TITLE
Load encounter info from JSON

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -45,8 +45,16 @@
         <processorPath useClasspath="true" />
         <module name="monsters-java" />
       </profile>
+      <profile default="false" name="Annotation profile for editor" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="true" />
+        <module name="editor" />
+      </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
+      <module name="editor" target="1.7" />
       <module name="monsters" target="1.5" />
       <module name="monsters-assets" target="1.7" />
       <module name="monsters-core" target="1.7" />

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -52,6 +52,13 @@
         <processorPath useClasspath="true" />
         <module name="editor" />
       </profile>
+      <profile default="false" name="Annotation profile for test-assets" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="true" />
+        <module name="test-assets" />
+      </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="editor" target="1.7" />
@@ -60,6 +67,7 @@
       <module name="monsters-core" target="1.7" />
       <module name="monsters-html" target="1.7" />
       <module name="monsters-java" target="1.7" />
+      <module name="test-assets" target="1.7" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -7,6 +7,7 @@
     <file url="file://$PROJECT_DIR$/editor" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/html" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/test-assets" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -4,6 +4,7 @@
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/assets" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/core" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/editor" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/html" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/java" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/editor/editor.iml" filepath="$PROJECT_DIR$/editor/editor.iml" />
       <module fileurl="file://$PROJECT_DIR$/monsters.iml" filepath="$PROJECT_DIR$/monsters.iml" />
       <module fileurl="file://$PROJECT_DIR$/assets/monsters-assets.iml" filepath="$PROJECT_DIR$/assets/monsters-assets.iml" />
       <module fileurl="file://$PROJECT_DIR$/core/monsters-core.iml" filepath="$PROJECT_DIR$/core/monsters-core.iml" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -8,6 +8,7 @@
       <module fileurl="file://$PROJECT_DIR$/core/monsters-core.iml" filepath="$PROJECT_DIR$/core/monsters-core.iml" />
       <module fileurl="file://$PROJECT_DIR$/html/monsters-html.iml" filepath="$PROJECT_DIR$/html/monsters-html.iml" />
       <module fileurl="file://$PROJECT_DIR$/java/monsters-java.iml" filepath="$PROJECT_DIR$/java/monsters-java.iml" />
+      <module fileurl="file://$PROJECT_DIR$/test-assets/test-assets.iml" filepath="$PROJECT_DIR$/test-assets/test-assets.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/runConfigurations/Unit_Tests.xml
+++ b/.idea/runConfigurations/Unit_Tests.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Unit Tests" type="JUnit" factoryName="JUnit" singleton="true">
     <extension name="coverage" enabled="false" merge="false" sample_coverage="true" runner="idea" />
-    <module name="monsters-core" />
+    <module name="" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
     <option name="ALTERNATIVE_JRE_PATH" />
     <option name="PACKAGE_NAME" value="" />
@@ -14,7 +14,7 @@
     <option name="ENV_VARIABLES" />
     <option name="PASS_PARENT_ENVS" value="true" />
     <option name="TEST_SEARCH_SCOPE">
-      <value defaultName="singleModule" />
+      <value defaultName="wholeProject" />
     </option>
     <envs />
     <patterns />

--- a/assets/src/main/resources/assets/encounters/cockatrice.json
+++ b/assets/src/main/resources/assets/encounters/cockatrice.json
@@ -1,0 +1,38 @@
+{
+  "name": "Angry Cockatrice",
+  "image": "cockatrice",
+  "reactions": [
+    {
+      "name": "Fight",
+      "story": {
+        "text": "You encounter an angry beast and charge forward to fight it like a silly English person.",
+        "triggers": [
+          {
+            "skill": "Weapon Use",
+            "conclusion": "You pound the tar out of that chicken thing."
+          },
+          {
+            "skill": "Logic",
+            "conclusion": "You make peace with the ugly bird lizard."
+          }
+        ]
+      }
+    },
+    {
+      "name": "Hide",
+      "story": {
+        "text": "You hear a terrifying sound and hide like a girly man",
+        "triggers": [
+          {
+            "skill": "Weapon use",
+            "conclusion": "You sharpen your weapon and hide in shame."
+          },
+          {
+            "skill": "Logic",
+            "conclusion": "You deduce a syllogism... for SCIENCE!"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/src/main/java/edu/bsu/storygame/core/EncounterConfiguration.java
+++ b/core/src/main/java/edu/bsu/storygame/core/EncounterConfiguration.java
@@ -1,0 +1,10 @@
+package edu.bsu.storygame.core;
+
+import edu.bsu.storygame.core.model.Encounter;
+import edu.bsu.storygame.core.model.Region;
+
+import java.util.List;
+
+public interface EncounterConfiguration {
+    List<Encounter> encountersFor(Region region);
+}

--- a/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
+++ b/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
@@ -11,6 +11,8 @@ import playn.scene.SceneGame;
 import pythagoras.f.IRectangle;
 import tripleplay.game.ScreenStack;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public class MonsterGame extends SceneGame {
 
     private static final float ASPECT_RATIO = 16f / 10f;
@@ -21,9 +23,11 @@ public class MonsterGame extends SceneGame {
     public final TileCache tileCache;
     public final GameBounds bounds;
     public final ScreenStack screenStack;
+    public final EncounterConfiguration encounters;
 
-    public MonsterGame(Platform plat) {
+    public MonsterGame(Platform plat, EncounterConfiguration encounterConfiguration) {
         super(plat, UPDATE_RATE_MS);
+        this.encounters = checkNotNull(encounterConfiguration);
         imageCache = new ImageCache(plat.assets());
         tileCache = new TileCache(plat.assets());
         initInput();

--- a/core/src/main/java/edu/bsu/storygame/core/PlaceholderEncounterFactory.java
+++ b/core/src/main/java/edu/bsu/storygame/core/PlaceholderEncounterFactory.java
@@ -1,0 +1,24 @@
+package edu.bsu.storygame.core;
+
+import edu.bsu.storygame.core.model.*;
+
+public final class PlaceholderEncounterFactory {
+
+    public static Encounter createEncounter() {
+        return Encounter.with("Angry Cockatrice")
+                .image("cockatrice")
+                .reaction(Reaction.create("Fight")
+                        .story(Story.withText("You aggressively see a thing")
+                                .trigger(SkillTrigger.skill(Skill.WEAPON_USE)
+                                        .conclusion("You stab it"))
+                                .trigger(SkillTrigger.skill(Skill.LOGIC)
+                                        .conclusion("You think it to death"))
+                                .build()))
+                .reaction(Reaction.create("Hide")
+                        .story(Story.withText("When you hear a thing, you hide.")
+                                .trigger(SkillTrigger.skill(Skill.WEAPON_USE)
+                                        .conclusion("Whatevs"))
+                                .build()))
+                .build();
+    }
+}

--- a/core/src/main/java/edu/bsu/storygame/core/model/Encounter.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Encounter.java
@@ -1,26 +1,82 @@
 package edu.bsu.storygame.core.model;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import edu.bsu.storygame.core.assets.ImageCache;
-import playn.core.Image;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Encounter {
 
-    public final Image image;
-    public final String name = "Angry Cockatrice";
-    public final ImmutableList<Reaction> reactions = ImmutableList.of(
-            new Reaction("Fight",
-                    new Story("You encounter an angry beast and charge forward to fight it like a silly English person.",
-                            ImmutableList.of(
-                                    new SkillTrigger(Skill.WEAPON_USE, "You pound the tar out of that chicken thing."),
-                                    new SkillTrigger(Skill.LOGIC, "You make peace with the ugly bird lizard.")))),
-            new Reaction("Hide",
-                    new Story("You hear a terrifying sound and hide like a girly man",
-                            ImmutableList.of(
-                                    new SkillTrigger(Skill.WEAPON_USE, "You spend the rest of the day sharpening your sword, not that you have the guts to use it."),
-                                    new SkillTrigger(Skill.LOGIC, "You relish the mustard of this dinner time.")))));
+    private static final int APPROXIMATE_MAX_CAPACITY = 4;
 
-    public Encounter(GameContext context) {
-        this.image = context.game.imageCache.image(ImageCache.Key.COCKATRICE);
+    public static Builder with(String name) {
+        return new Builder(name);
+    }
+
+    public static final class Builder {
+        private String name;
+        private String imageKey;
+        private List<Reaction> reactions = Lists.newArrayListWithCapacity(APPROXIMATE_MAX_CAPACITY);
+
+        private Builder(String name) {
+            this.name = checkNotNull(name);
+        }
+
+        public Builder image(String path) {
+            this.imageKey = checkNotNull(path);
+            return this;
+        }
+
+        public Builder reaction(Reaction reaction) {
+            checkNotNull(reaction);
+            this.reactions.add(reaction);
+            return this;
+        }
+
+        public Encounter build() {
+            return new Encounter(this);
+        }
+    }
+
+    public final String name;
+    public final String imageKey;
+    public final ImmutableList<Reaction> reactions;
+
+    private Encounter(Builder builder) {
+        this.name = builder.name;
+        this.imageKey = checkNotNull(builder.imageKey);
+        this.reactions = ImmutableList.copyOf(builder.reactions);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("name", name)
+                .add("imageKey", imageKey)
+                .add("reactions", reactions)
+                .toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, imageKey, reactions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof Encounter) {
+            Encounter other = (Encounter) obj;
+            return Objects.equals(this.name, other.name)
+                    && Objects.equals(this.imageKey, other.imageKey)
+                    && Objects.equals(this.reactions, other.reactions);
+        } else {
+            return false;
+        }
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/model/Reaction.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Reaction.java
@@ -1,18 +1,62 @@
 package edu.bsu.storygame.core.model;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.base.MoreObjects;
 
-import java.util.List;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class Reaction {
+public final class Reaction {
+
+    public static Builder create(String name) {
+        return new Builder(name);
+    }
+
+    public static final class Builder {
+        private final String name;
+        private Story story;
+
+        private Builder(String name) {
+            this.name = checkNotNull(name);
+        }
+
+        public Reaction story(Story story) {
+            this.story = checkNotNull(story);
+            return new Reaction(this);
+        }
+    }
+
     public final String name;
     public final Story story;
 
+    private Reaction(Builder builder) {
+        this.name = builder.name;
+        this.story = builder.story;
+    }
 
-    public Reaction(String name, Story story) {
-        this.name = checkNotNull(name);
-        this.story = checkNotNull(story);
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("name", name)
+                .add("story", story)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof Reaction) {
+            Reaction other = (Reaction) obj;
+            return Objects.equals(this.name, other.name)
+                    && Objects.equals(this.story, other.story);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, story);
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/model/Skill.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Skill.java
@@ -1,5 +1,7 @@
 package edu.bsu.storygame.core.model;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 public enum Skill {
     WEAPON_USE("Weapon Use"),
     ATHLETICISM("Athleticism"),
@@ -12,5 +14,15 @@ public enum Skill {
 
     Skill(String text) {
         this.text = text;
+    }
+
+    public static Skill parse(String in) {
+        checkNotNull(in);
+        for (Skill skill : values()) {
+            if (skill.text.equalsIgnoreCase(in)) {
+                return skill;
+            }
+        }
+        throw new IllegalArgumentException("No such skill as " + in);
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/model/SkillTrigger.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/SkillTrigger.java
@@ -1,12 +1,62 @@
 package edu.bsu.storygame.core.model;
 
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class SkillTrigger {
+public final class SkillTrigger {
+
+    public static Builder skill(Skill skill) {
+        return new Builder(skill);
+    }
+
+    public static final class Builder {
+        private final Skill skill;
+        private String conclusion;
+
+        private Builder(Skill skill) {
+            this.skill = checkNotNull(skill);
+        }
+
+        public SkillTrigger conclusion(String conclusion) {
+            this.conclusion = checkNotNull(conclusion);
+            return new SkillTrigger(this);
+        }
+    }
+
     public final Skill skill;
-    public final String story;
-    public SkillTrigger(Skill skill, String story) {
-        this.skill = checkNotNull(skill);
-        this.story = checkNotNull(story);
+    public final String conclusion;
+
+    private SkillTrigger(Builder builder) {
+        this.skill = builder.skill;
+        this.conclusion = builder.conclusion;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("skill", skill)
+                .add("conclusion", conclusion)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof SkillTrigger) {
+            SkillTrigger other = (SkillTrigger) obj;
+            return Objects.equals(this.skill, other.skill)
+                    && Objects.equals(this.conclusion, other.conclusion);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(skill, conclusion);
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/model/Story.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Story.java
@@ -1,20 +1,67 @@
 package edu.bsu.storygame.core.model;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.List;
+import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+public final class Story {
 
-public class Story {
+    public static Builder withText(String text) {
+        return new Builder(text);
+    }
+
+    public static final class Builder {
+        private final String text;
+        private final List<SkillTrigger> triggers = Lists.newArrayList();
+
+        private Builder(String text) {
+            this.text = text;
+        }
+
+        public Builder trigger(SkillTrigger skillTrigger) {
+            triggers.add(skillTrigger);
+            return this;
+        }
+
+        public Story build() {
+            return new Story(this);
+        }
+    }
+
     public final String text;
     public final ImmutableList<SkillTrigger> triggers;
 
-    public Story(String text, List<SkillTrigger> triggers) {
-        this.text = checkNotNull(text);
-        checkArgument(!text.trim().isEmpty(), "Text may not be empty");
-        this.triggers = ImmutableList.copyOf(triggers);
-        checkArgument(!triggers.isEmpty(), "Must have at least one trigger");
+    private Story(Builder builder) {
+        this.text = builder.text;
+        this.triggers = ImmutableList.copyOf(builder.triggers);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("text", text)
+                .add("triggers", triggers)
+                .toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text, triggers);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof Story) {
+            Story other = (Story) obj;
+            return Objects.equals(this.text, other.text)
+                    && Objects.equals(this.triggers, other.triggers);
+        } else {
+            return false;
+        }
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/view/EncounterView.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/EncounterView.java
@@ -1,14 +1,15 @@
 package edu.bsu.storygame.core.view;
 
-import edu.bsu.storygame.core.model.GameContext;
+import edu.bsu.storygame.core.assets.ImageCache;
 import edu.bsu.storygame.core.model.Encounter;
+import edu.bsu.storygame.core.model.GameContext;
 import edu.bsu.storygame.core.model.Phase;
 import edu.bsu.storygame.core.model.Reaction;
 import react.Slot;
 import tripleplay.ui.*;
 import tripleplay.ui.layout.AxisLayout;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.*;
 
 public class EncounterView extends Group {
     private final GameContext context;
@@ -16,7 +17,8 @@ public class EncounterView extends Group {
     public EncounterView(final GameContext context, Encounter encounter) {
         super(AxisLayout.vertical());
         this.context = checkNotNull(context);
-        add(new Label(encounter.name, Icons.scaled(Icons.image(encounter.image), 0.25f))
+        add(new Label(encounter.name,
+                Icons.scaled(Icons.image(context.game.imageCache.image(ImageCache.Key.valueOf(encounter.imageKey.toUpperCase()))), 0.25f))
                 .setStyles(Style.ICON_POS.above));
         Group reactionBox = new Group(AxisLayout.horizontal());
         for (final Reaction reaction : encounter.reactions) {
@@ -43,6 +45,7 @@ public class EncounterView extends Group {
             });
             updateEnabledStatusBasedOn(context.phase.get());
         }
+
         private void updateEnabledStatusBasedOn(Phase phase) {
             setEnabled(phase.equals(Phase.ENCOUNTER));
         }

--- a/core/src/main/java/edu/bsu/storygame/core/view/SampleGameScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/SampleGameScreen.java
@@ -2,7 +2,6 @@ package edu.bsu.storygame.core.view;
 
 import edu.bsu.storygame.core.MonsterGame;
 import edu.bsu.storygame.core.assets.TileCache;
-import edu.bsu.storygame.core.model.Encounter;
 import edu.bsu.storygame.core.model.GameContext;
 import edu.bsu.storygame.core.model.Phase;
 import edu.bsu.storygame.core.model.Player;
@@ -16,7 +15,7 @@ import tripleplay.ui.*;
 import tripleplay.ui.layout.AxisLayout;
 import tripleplay.util.Colors;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class SampleGameScreen extends ScreenStack.UIScreen {
 
@@ -49,12 +48,12 @@ public class SampleGameScreen extends ScreenStack.UIScreen {
                 final Root dialog = iface.createRoot(AxisLayout.vertical(), SimpleStyles.newSheet(game.plat.graphics()), boundedLayer);
                 dialog.setStyles(Style.BACKGROUND.is(Background.solid(Colors.LIGHT_GRAY)));
                 dialog.setSize(boundedLayer.width() * SIZE_PERCENT, boundedLayer.height() * SIZE_PERCENT)
-                        .setLocation(boundedLayer.width() * (1-SIZE_PERCENT)/2, boundedLayer.height());
+                        .setLocation(boundedLayer.width() * (1 - SIZE_PERCENT) / 2, boundedLayer.height());
                 iface.anim.tweenY(dialog.layer)
-                        .to(boundedLayer.height() * (1-SIZE_PERCENT)/2)
+                        .to(boundedLayer.height() * (1 - SIZE_PERCENT) / 2)
                         .in(200f)
                         .easeIn();
-                dialog.add(new EncounterView(context, new Encounter(context)));
+                dialog.add(new EncounterView(context, game.encounters.encountersFor(null).get(0)));
 
                 connection = context.phase.connect(new Slot<Phase>() {
                     @Override
@@ -93,20 +92,20 @@ public class SampleGameScreen extends ScreenStack.UIScreen {
                     }
                 })
                 .add(new Label() {
-                         {
-                             updateText();
-                             SampleGameScreen.this.context.phase.connect(new Slot<Phase>() {
-                                 @Override
-                                 public void onEmit(Phase phase) {
-                                     updateText();
-                                 }
-                             });
-                         }
+                    {
+                        updateText();
+                        SampleGameScreen.this.context.phase.connect(new Slot<Phase>() {
+                            @Override
+                            public void onEmit(Phase phase) {
+                                updateText();
+                            }
+                        });
+                    }
 
-                         private void updateText() {
-                             text.update("Current phase: " + context.phase.get().name());
-                         }
-                     })
+                    private void updateText() {
+                        text.update("Current phase: " + context.phase.get().name());
+                    }
+                })
 
                 .add(new Label() {
                          {

--- a/core/src/main/java/edu/bsu/storygame/core/view/StoryView.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/StoryView.java
@@ -1,9 +1,15 @@
 package edu.bsu.storygame.core.view;
 
 import com.google.common.collect.Lists;
-import edu.bsu.storygame.core.model.*;
+import edu.bsu.storygame.core.model.GameContext;
+import edu.bsu.storygame.core.model.Phase;
+import edu.bsu.storygame.core.model.SkillTrigger;
+import edu.bsu.storygame.core.model.Story;
 import react.Slot;
-import tripleplay.ui.*;
+import tripleplay.ui.Button;
+import tripleplay.ui.Group;
+import tripleplay.ui.Label;
+import tripleplay.ui.Style;
 import tripleplay.ui.layout.AxisLayout;
 
 import java.util.List;
@@ -24,7 +30,7 @@ public class StoryView extends Group {
                             for (Button b : buttons) {
                                 b.setEnabled(false);
                             }
-                            add(new Label(trigger.story)
+                            add(new Label(trigger.conclusion)
                                     .addStyles(Style.TEXT_WRAP.on));
                             add(new Button("OK")
                                     .onClick(new Slot<Button>() {

--- a/core/src/test/java/edu/bsu/storygame/core/ListTest.java
+++ b/core/src/test/java/edu/bsu/storygame/core/ListTest.java
@@ -1,0 +1,29 @@
+package edu.bsu.storygame.core;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ListTest {
+    @Test
+    public void testTwoEmptyImmutableListsAreEqual() {
+        //noinspection EqualsWithItself
+        assertTrue(ImmutableList.of().equals(ImmutableList.of()));
+    }
+
+    @Test
+    public void testTwoEmptyImmutableListsHaveSameHashCode() {
+        assertTrue(ImmutableList.of().hashCode() == ImmutableList.of().hashCode());
+    }
+
+    @Test
+    public void testTwoImmutableListsWithSameContentAreEqual() {
+        assertTrue(ImmutableList.of(1).equals(ImmutableList.of(1)));
+    }
+
+    @Test
+    public void testTwoImmutableListsWithSameContentHaveSameHashcode() {
+        assertTrue(ImmutableList.of(1).hashCode() == ImmutableList.of(1).hashCode());
+    }
+}

--- a/core/src/test/java/edu/bsu/storygame/core/model/EncounterTest.java
+++ b/core/src/test/java/edu/bsu/storygame/core/model/EncounterTest.java
@@ -1,0 +1,61 @@
+package edu.bsu.storygame.core.model;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EncounterTest {
+
+    private Encounter encounter;
+
+    @Test
+    public void testCreate() {
+        givenASampleEncounter();
+        assertEquals(2, encounter.reactions.size());
+    }
+
+    @Test
+    public void testCreate_firstReaction() {
+        givenASampleEncounter();
+        assertEquals("Fight", encounter.reactions.get(0).name);
+    }
+
+    @Test
+    public void testCreate_secondReaction() {
+        givenASampleEncounter();
+        assertEquals("Hide", encounter.reactions.get(1).name);
+    }
+
+    private void givenASampleEncounter() {
+        encounter = makeSampleEncounter();
+    }
+
+    private Encounter makeSampleEncounter() {
+        return Encounter.with("Angry Cockatrice")
+                .image("cockatrice.png")
+                .reaction(Reaction.create("Fight")
+                        .story(Story.withText("You aggressively see a thing")
+                                .trigger(SkillTrigger.skill(Skill.WEAPON_USE)
+                                        .conclusion("You stab it"))
+                                .trigger(SkillTrigger.skill(Skill.LOGIC)
+                                        .conclusion("You think it to death"))
+                                .build()))
+                .reaction(Reaction.create("Hide")
+                        .story(Story.withText("When you hear a thing, you hide.")
+                                .trigger(SkillTrigger.skill(Skill.WEAPON_USE)
+                                        .conclusion("Whatevs"))
+                                .build()))
+                .build();
+    }
+
+    @Test
+    public void testEquals() {
+        Encounter e1 = makeSampleEncounter();
+        Encounter e2 = makeSampleEncounter();
+        Encounter e3 = Encounter.with("something else").image("foo").build();
+        new EqualsTester().addEqualityGroup(e1, e2)
+                .addEqualityGroup(e3)
+                .testEquals();
+    }
+}

--- a/core/src/test/java/edu/bsu/storygame/core/model/PhaseTest.java
+++ b/core/src/test/java/edu/bsu/storygame/core/model/PhaseTest.java
@@ -1,6 +1,5 @@
 package edu.bsu.storygame.core.model;
 
-import edu.bsu.storygame.core.model.Phase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/editor/editor.iml
+++ b/editor/editor.iml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+  </component>
+</module>

--- a/editor/editor.iml
+++ b/editor/editor.iml
@@ -7,10 +7,12 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="test-assets" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/editor/pom.xml
+++ b/editor/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>monsters</artifactId>
+        <groupId>edu.bsu.storygame</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>editor</artifactId>
+
+
+</project>

--- a/editor/src/test/java/edu/bsu/storygame/editor/AssetTest.java
+++ b/editor/src/test/java/edu/bsu/storygame/editor/AssetTest.java
@@ -1,0 +1,18 @@
+package edu.bsu.storygame.editor;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
+
+public class AssetTest {
+
+    @Test
+    public void testLoadAssetFromTestAssetsModule() throws IOException {
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("test-encounters/cockatrice.json");
+        assertNotNull("Cannot find resource.", in);
+        in.close();
+    }
+}

--- a/html/monsters-html.iml
+++ b/html/monsters-html.iml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/html/src/main/java/edu/bsu/storygame/html/MonsterGameHtml.java
+++ b/html/src/main/java/edu/bsu/storygame/html/MonsterGameHtml.java
@@ -1,8 +1,15 @@
 package edu.bsu.storygame.html;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gwt.core.client.EntryPoint;
-import playn.html.HtmlPlatform;
+import edu.bsu.storygame.core.EncounterConfiguration;
 import edu.bsu.storygame.core.MonsterGame;
+import edu.bsu.storygame.core.PlaceholderEncounterFactory;
+import edu.bsu.storygame.core.model.Encounter;
+import edu.bsu.storygame.core.model.Region;
+import playn.html.HtmlPlatform;
+
+import java.util.List;
 
 public class MonsterGameHtml implements EntryPoint {
 
@@ -11,7 +18,12 @@ public class MonsterGameHtml implements EntryPoint {
     // use config to customize the HTML platform, if needed
     HtmlPlatform plat = new HtmlPlatform(config);
     plat.assets().setPathPrefix("monsters/");
-    new MonsterGame(plat);
+    new MonsterGame(plat, new EncounterConfiguration() {
+      @Override
+      public List<Encounter> encountersFor(Region region) {
+        return ImmutableList.of(PlaceholderEncounterFactory.createEncounter());
+      }
+    });
     plat.start();
   }
 }

--- a/java/monsters-java.iml
+++ b/java/monsters-java.iml
@@ -5,6 +5,7 @@
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -32,6 +33,8 @@
     <orderEntry type="library" name="Maven: org.lwjgl:lwjgl-platform:natives-windows:3.0.0b" level="project" />
     <orderEntry type="library" name="Maven: org.lwjgl:lwjgl-platform:natives-osx:3.0.0b" level="project" />
     <orderEntry type="library" name="Maven: commons-cli:commons-cli:1.2" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.6.1" level="project" />
+    <orderEntry type="module" module-name="test-assets" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -41,6 +41,19 @@
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.6.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>edu.bsu.storygame</groupId>
+            <artifactId>test-assets</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/src/main/java/edu/bsu/storygame/java/EncounterAdapter.java
+++ b/java/src/main/java/edu/bsu/storygame/java/EncounterAdapter.java
@@ -1,0 +1,45 @@
+package edu.bsu.storygame.java;
+
+import com.google.gson.*;
+import edu.bsu.storygame.core.model.*;
+
+import java.lang.reflect.Type;
+
+public class EncounterAdapter implements JsonDeserializer<Encounter> {
+    @Override
+    public Encounter deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        final String name = ((JsonObject) jsonElement).get("name").getAsString();
+        final String imageKey = ((JsonObject) jsonElement).get("image").getAsString();
+        Encounter.Builder builder = Encounter.with(name)
+                .image(imageKey);
+
+        JsonArray reactions = ((JsonObject) jsonElement).getAsJsonArray("reactions");
+        for (JsonElement reactionElement : reactions) {
+            Reaction reaction = parseReaction(reactionElement);
+            builder.reaction(reaction);
+        }
+        return builder.build();
+    }
+
+    private Reaction parseReaction(JsonElement reactionElement) {
+        final JsonObject reaction = (JsonObject) reactionElement;
+        final String name = reaction.get("name").getAsString();
+        final JsonObject story = reaction.getAsJsonObject("story");
+        return Reaction.create(name)
+                .story(parseStory(story));
+    }
+
+    private Story parseStory(JsonObject story) {
+        final String text = story.get("text").getAsString();
+        final Story.Builder storyBuilder = Story.withText(text);
+        final JsonArray triggers = story.getAsJsonArray("triggers");
+        for (JsonElement element : triggers) {
+            JsonObject trigger = (JsonObject) element;
+            final String skillString = trigger.get("skill").getAsString();
+            final Skill skill = Skill.parse(skillString);
+            final String conclusion = trigger.get("conclusion").getAsString();
+            storyBuilder.trigger(SkillTrigger.skill(skill).conclusion(conclusion));
+        }
+        return storyBuilder.build();
+    }
+}

--- a/java/src/main/java/edu/bsu/storygame/java/EncounterParser.java
+++ b/java/src/main/java/edu/bsu/storygame/java/EncounterParser.java
@@ -1,0 +1,22 @@
+package edu.bsu.storygame.java;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import edu.bsu.storygame.core.model.Encounter;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class EncounterParser {
+    public Encounter parse(InputStream in) {
+        checkNotNull(in);
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(Encounter.class, new EncounterAdapter())
+                .create();
+        JsonReader reader = new JsonReader(new InputStreamReader(in));
+        return gson.fromJson(reader, Encounter.class);
+    }
+}

--- a/java/src/main/java/edu/bsu/storygame/java/MonsterGameJava.java
+++ b/java/src/main/java/edu/bsu/storygame/java/MonsterGameJava.java
@@ -1,14 +1,19 @@
 package edu.bsu.storygame.java;
 
+import com.google.common.collect.ImmutableList;
+import edu.bsu.storygame.core.EncounterConfiguration;
+import edu.bsu.storygame.core.MonsterGame;
 import edu.bsu.storygame.core.assets.FontConstants;
+import edu.bsu.storygame.core.model.Encounter;
+import edu.bsu.storygame.core.model.Region;
 import org.apache.commons.cli.*;
-
 import playn.java.JavaPlatform;
 import playn.java.LWJGLPlatform;
-
-import edu.bsu.storygame.core.MonsterGame;
 import pythagoras.i.Dimension;
 import pythagoras.i.IDimension;
+
+import java.io.InputStream;
+import java.util.List;
 
 public class MonsterGameJava {
 
@@ -30,7 +35,7 @@ public class MonsterGameJava {
 
         LWJGLPlatform plat = new LWJGLPlatform(config);
         registerFonts(plat);
-        new MonsterGame(plat);
+        new MonsterGame(plat, createEncounterConfiguration());
         plat.start();
     }
 
@@ -45,6 +50,18 @@ public class MonsterGameJava {
         } catch (Exception e) {
             plat.log().error("Failed to load font", e);
         }
+    }
+
+    private static EncounterConfiguration createEncounterConfiguration() {
+        return new EncounterConfiguration() {
+            @Override
+            public List<Encounter> encountersFor(Region region) {
+                EncounterParser parser = new EncounterParser();
+                InputStream source = Thread.currentThread().getContextClassLoader().getResourceAsStream("assets/encounters/cockatrice.json");
+                Encounter encounter = parser.parse(source);
+                return ImmutableList.of(encounter);
+            }
+        };
     }
 
     private static final class CommandLineParser extends BasicParser {

--- a/java/src/test/java/edu/bsu/storygame/java/EncounterParserTest.java
+++ b/java/src/test/java/edu/bsu/storygame/java/EncounterParserTest.java
@@ -1,0 +1,38 @@
+package edu.bsu.storygame.java;
+
+import edu.bsu.storygame.core.model.*;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+public class EncounterParserTest {
+
+    private final Encounter expected =
+            Encounter.with("Cockatrice")
+                    .image("pic")
+                    .reaction(Reaction.create("Fight")
+                            .story(Story.withText("Story 1")
+                                    .trigger(SkillTrigger.skill(Skill.LOGIC)
+                                            .conclusion("Conclusion 1"))
+                                    .trigger(SkillTrigger.skill(Skill.MAGIC)
+                                            .conclusion("Conclusion 2"))
+                                    .build()))
+                    .reaction(Reaction.create("Hide")
+                            .story(Story.withText("Story 2")
+                                    .trigger(SkillTrigger.skill(Skill.LOGIC)
+                                            .conclusion("Conclusion 1-A"))
+                                    .trigger(SkillTrigger.skill(Skill.MAGIC)
+                                            .conclusion("Conclusion 2-B"))
+                                    .build()))
+                    .build();
+
+    @Test
+    public void testParse() {
+        EncounterParser parser = new EncounterParser();
+        InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("test-encounters/cockatrice.json");
+        Encounter encounter = parser.parse(in);
+        assertEquals(expected, encounter);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,17 @@
                 <module>editor</module>
             </modules>
         </profile>
+        <profile>
+            <id>test-assets</id>
+            <modules>
+                <module>test-assets</module>
+            </modules>
+        </profile>
     </profiles>
     <modules>
         <module>assets</module>
         <module>core</module>
         <module>editor</module>
+        <module>test-assets</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,16 @@
                 <module>html</module>
             </modules>
         </profile>
+        <profile>
+            <id>editor</id>
+            <modules>
+                <module>editor</module>
+            </modules>
+        </profile>
     </profiles>
     <modules>
         <module>assets</module>
         <module>core</module>
+        <module>editor</module>
     </modules>
 </project>

--- a/test-assets/pom.xml
+++ b/test-assets/pom.xml
@@ -9,15 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>editor</artifactId>
+    <artifactId>test-assets</artifactId>
 
-    <dependencies>
-        <dependency>
-            <groupId>edu.bsu.storygame</groupId>
-            <artifactId>test-assets</artifactId>
-            <version>1.0-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/test-assets/src/main/resources/test-encounters/cockatrice.json
+++ b/test-assets/src/main/resources/test-encounters/cockatrice.json
@@ -1,0 +1,38 @@
+{
+  "name": "Cockatrice",
+  "image": "pic",
+  "reactions": [
+    {
+      "name": "Fight",
+      "story": {
+        "text": "Story 1",
+        "triggers": [
+          {
+            "skill": "Logic",
+            "conclusion": "Conclusion 1"
+          },
+          {
+            "skill": "Magic",
+            "conclusion": "Conclusion 2"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Hide",
+      "story": {
+        "text": "Story 2",
+        "triggers": [
+          {
+            "skill": "Logic",
+            "conclusion": "Conclusion 1-A"
+          },
+          {
+            "skill": "Magic",
+            "conclusion": "Conclusion 2-B"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test-assets/test-assets.iml
+++ b/test-assets/test-assets.iml
@@ -4,8 +4,9 @@
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />


### PR DESCRIPTION
This branch started as an experiment with creating a separate module for a user-friendly story editor. Quickly, though, I had to start dealing with parsing encounters. This pull request would bring into master a few critical changes:
* Updates to the core domain model, providing builders along with equals, toString, hashCode
* On the java target, the encounter is parsed from encounters/cockatrice.png rather than hardcoded

Note that the HTML target is still using a placeholder. Parsing there would be similar to the Java target, but it cannot use the same library. There seems to be no JSON parser that works happily in both Java and GWT, and hence the separation.

The most important part here is that I had to march through a lot of files in order  to get this working, so I didn't want this one important feature---loading from JSON---to get too far from master, even though HTML target parsing and any kind of editor are not yet working.