### PR TITLE
Add debug mode with keyboard shortcut to skip character creation

### DIFF
--- a/core/src/main/java/edu/bsu/storygame/core/DebugMode.java
+++ b/core/src/main/java/edu/bsu/storygame/core/DebugMode.java
@@ -1,0 +1,63 @@
+package edu.bsu.storygame.core;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import edu.bsu.storygame.core.model.GameContext;
+import edu.bsu.storygame.core.model.Player;
+import edu.bsu.storygame.core.view.SampleGameScreen;
+import playn.core.Key;
+import playn.core.Keyboard;
+import react.RList;
+import react.SignalView;
+import tripleplay.util.Colors;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DebugMode implements SignalView.Listener<Keyboard.Event> {
+
+    private static final ImmutableList<String> SAMPLE_SKILLS = ImmutableList.of("Skill 1", "Skill 2");
+
+    private final ImmutableMap.Builder<Key, Runnable> builder = ImmutableMap.builder();
+
+    {
+        builder.put(Key.D, new Runnable() {
+            @Override
+            public void run() {
+                GameContext context = new GameContext(game,
+                        new Player("Ann", Colors.WHITE, makeSkillList()),
+                        new Player("Barb", Colors.BLACK, makeSkillList()));
+                game.screenStack.push(new SampleGameScreen(game, context));
+            }
+
+            private RList<String> makeSkillList() {
+                RList<String> list = RList.create();
+                list.addAll(SAMPLE_SKILLS);
+                return list;
+            }
+        });
+    }
+
+    private final MonsterGame game;
+    private final ImmutableMap<Key, Runnable> actionMap = builder.build();
+
+    public DebugMode(MonsterGame game) {
+        this.game = checkNotNull(game);
+    }
+
+
+    @Override
+    public void onEmit(Keyboard.Event event) {
+        if (event instanceof Keyboard.KeyEvent) {
+            Keyboard.KeyEvent keyEvent = (Keyboard.KeyEvent) event;
+            if (isActionTrigger(keyEvent)) {
+                actionMap.get(keyEvent.key).run();
+            }
+        }
+    }
+
+    private boolean isActionTrigger(Keyboard.KeyEvent keyEvent) {
+        return keyEvent.down
+                && keyEvent.isAltDown()
+                && actionMap.containsKey(keyEvent.key);
+    }
+}

--- a/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
+++ b/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
@@ -24,6 +24,7 @@ public class MonsterGame extends SceneGame {
     public static final class Config {
         public Platform platform;
         public Narrative narrativeOverride;
+        public boolean debugMode = false;
 
         public Config(Platform plat) {
             this.platform = checkNotNull(plat);
@@ -45,6 +46,9 @@ public class MonsterGame extends SceneGame {
                         ? new NarrativeCache.Default(this)
                         : new NarrativeCache.Overridden(config.narrativeOverride);
         initInput();
+        if (config.debugMode) {
+            plat.input().keyboardEvents.connect(new DebugMode(this));
+        }
         this.bounds = initAspectRatio();
         screenStack = new ScreenStack(this, rootLayer);
         screenStack.push(new LoadingScreen(this, screenStack));

--- a/java/src/main/java/edu/bsu/storygame/java/MonsterGameJava.java
+++ b/java/src/main/java/edu/bsu/storygame/java/MonsterGameJava.java
@@ -28,7 +28,10 @@ public class MonsterGameJava {
 
         LWJGLPlatform plat = new LWJGLPlatform(config);
         registerFonts(plat);
-        new MonsterGame(new MonsterGame.Config(plat));
+
+        MonsterGame.Config gameConf = new MonsterGame.Config(plat);
+        gameConf.debugMode = true;
+        new MonsterGame(gameConf);
         plat.start();
     }
 


### PR DESCRIPTION
Use Alt-D to jump into the game with basic characters in place. The characters have made-up skills. This allows for rapid testing of the map without having to click through the character creation process. Other keyboard shortcuts can be handled in a similar way. Note that the Java back-end has debug mode turned on by default, and the HTML back-end does not.