### PR TITLE
Reintroduce the Skill abstraction

### DIFF
--- a/core/src/main/java/edu/bsu/storygame/core/DebugMode.java
+++ b/core/src/main/java/edu/bsu/storygame/core/DebugMode.java
@@ -2,20 +2,26 @@ package edu.bsu.storygame.core;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import edu.bsu.storygame.core.model.GameContext;
 import edu.bsu.storygame.core.model.Player;
+import edu.bsu.storygame.core.model.Skill;
 import edu.bsu.storygame.core.view.SampleGameScreen;
 import playn.core.Key;
 import playn.core.Keyboard;
-import react.RList;
 import react.SignalView;
 import tripleplay.util.Colors;
+
+import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class DebugMode implements SignalView.Listener<Keyboard.Event> {
 
-    private static final ImmutableList<String> SAMPLE_SKILLS = ImmutableList.of("WEAPON_USE", "MAGIC");
+    private static final ImmutableList<Skill> SAMPLE_SKILLS = ImmutableList.of(
+            Skill.named("Weapon use"),
+            Skill.named("Magic")
+    );
 
     private final ImmutableMap.Builder<Key, Runnable> builder = ImmutableMap.builder();
 
@@ -29,8 +35,8 @@ public class DebugMode implements SignalView.Listener<Keyboard.Event> {
                 game.screenStack.push(new SampleGameScreen(game, context));
             }
 
-            private RList<String> makeSkillList() {
-                RList<String> list = RList.create();
+            private List<Skill> makeSkillList() {
+                List<Skill> list = Lists.newArrayList();
                 list.addAll(SAMPLE_SKILLS);
                 return list;
             }

--- a/core/src/main/java/edu/bsu/storygame/core/json/EncounterParser.java
+++ b/core/src/main/java/edu/bsu/storygame/core/json/EncounterParser.java
@@ -39,7 +39,7 @@ public final class EncounterParser {
         Json.Array jsonTriggers = jsonStory.getArray("triggers");
         for (int i = 0, limit = jsonTriggers.length(); i < limit; i++) {
             Json.Object jsonTrigger = jsonTriggers.getObject(i);
-            String skill = jsonTrigger.getString("skill");
+            Skill skill = Skill.named(jsonTrigger.getString("skill"));
             Json.Object conclusionObject = jsonTrigger.getObject("conclusion");
             Conclusion conclusion = parseConclusion(conclusionObject);
             storyBuilder.trigger(SkillTrigger.skill(skill).conclusion(conclusion));
@@ -54,7 +54,10 @@ public final class EncounterParser {
         checkNotNull(text, "Conclusion must have text");
         builder.text(text);
         builder.points(conclusionObject.getInt("points"));
-        builder.skill(conclusionObject.getString("skill"));
+        String skillReward = conclusionObject.getString("skill");
+        if (skillReward != null) {
+            builder.skill(Skill.named(skillReward));
+        }
         return builder.build();
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/json/SkillParser.java
+++ b/core/src/main/java/edu/bsu/storygame/core/json/SkillParser.java
@@ -1,0 +1,22 @@
+package edu.bsu.storygame.core.json;
+
+import com.google.common.collect.Maps;
+import edu.bsu.storygame.core.model.Skill;
+
+import java.util.Map;
+
+public class SkillParser {
+
+    private final Map<String, Skill> cachedSkills = Maps.newHashMap();
+
+    public Skill parse(String name) {
+        String lowercase = name.toLowerCase();
+        if (cachedSkills.containsKey(lowercase)) {
+            return cachedSkills.get(lowercase);
+        } else {
+            Skill skill = Skill.named(lowercase);
+            cachedSkills.put(lowercase, skill);
+            return skill;
+        }
+    }
+}

--- a/core/src/main/java/edu/bsu/storygame/core/model/Conclusion.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Conclusion.java
@@ -9,7 +9,7 @@ public final class Conclusion {
     public static class Builder {
         private String text;
         private int points = 0;
-        private String skill = null;
+        private Skill skill = null;
 
         public Builder text(String text) {
             this.text = text;
@@ -21,7 +21,7 @@ public final class Conclusion {
             return this;
         }
 
-        public Builder skill(String skill) {
+        public Builder skill(Skill skill) {
             this.skill = skill;
             return this;
         }
@@ -33,7 +33,7 @@ public final class Conclusion {
 
     public final String text;
     public final int points;
-    public final String skill;
+    public final Skill skill;
 
     private Conclusion(Builder importer) {
         this.text = importer.text;

--- a/core/src/main/java/edu/bsu/storygame/core/model/Narrative.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Narrative.java
@@ -38,8 +38,8 @@ public final class Narrative {
         return map.get(region);
     }
 
-    public Set<String> skills() {
-        Set<String> result = Sets.newTreeSet();
+    public Set<Skill> skills() {
+        Set<Skill> result = Sets.newTreeSet();
         for (EncounterDeck deck : map.values()) {
             for (Encounter encounter : deck) {
                 for (Reaction reaction : encounter.reactions) {

--- a/core/src/main/java/edu/bsu/storygame/core/model/Player.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Player.java
@@ -1,15 +1,19 @@
 package edu.bsu.storygame.core.model;
 
+import com.google.common.collect.Lists;
 import react.RList;
 import react.Value;
 
-import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
 
 public class Player {
 
     public final String name;
     public final int color;
-    public RList<String> skills = new RList<>(new ArrayList<String>());
+    public RList<Skill> skills;
     public Value<Integer> storyPoints = Value.create(0);
     public final Value<Region> location = Value.create(Region.AFRICA);
 
@@ -17,7 +21,7 @@ public class Player {
 
         private String name;
         private int color;
-        public RList<String> skills = new RList<>(new ArrayList<String>());
+        private List<Skill> skills;
 
         public Builder name(String name) {
             this.name = name;
@@ -29,8 +33,10 @@ public class Player {
             return this;
         }
 
-        public Builder skills(RList<String> skills) {
-            this.skills = skills;
+        public Builder skills(List<Skill> skills) {
+            checkState(this.skills == null, "Skills already specified");
+            this.skills = Lists.newArrayList(skills);
+            Collections.sort(this.skills);
             return this;
         }
 
@@ -42,7 +48,7 @@ public class Player {
     private Player(Builder builder) {
         this.name = builder.name;
         this.color = builder.color;
-        this.skills = builder.skills;
+        this.skills = RList.create(builder.skills);
     }
 
 }

--- a/core/src/main/java/edu/bsu/storygame/core/model/Skill.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/Skill.java
@@ -1,0 +1,54 @@
+package edu.bsu.storygame.core.model;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+public final class Skill implements Comparable<Skill> {
+
+    public static Skill named(String name) {
+        String normalized = toTitleCase(name);
+        return new Skill(normalized);
+    }
+
+    private static String toTitleCase(String name) {
+        return String.valueOf(Character.toUpperCase(name.charAt(0))) +
+                name.substring(1).toLowerCase();
+    }
+
+    public final String name;
+
+    private Skill(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).add("name", name).toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        } else if (obj instanceof Skill) {
+            Skill other = (Skill) obj;
+            return this.name.equals(other.name);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    // IntelliJ IDEA wants to annotate the method with @NotNull, but that's inferred--not inherited--and we
+    // don't want to confuse the rest of the compiler settings.
+    @SuppressWarnings("NullableProblems")
+    @Override
+    public int compareTo(Skill other) {
+        return this.name.compareTo(other.name);
+    }
+}

--- a/core/src/main/java/edu/bsu/storygame/core/model/SkillTrigger.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/SkillTrigger.java
@@ -8,15 +8,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class SkillTrigger {
 
-    public static Builder skill(String skill) {
+    public static Builder skill(Skill skill) {
         return new Builder(skill);
     }
 
     public static final class Builder {
-        private final String skill;
+        private final Skill skill;
         private Conclusion conclusion;
 
-        private Builder(String skill) {
+        private Builder(Skill skill) {
             this.skill = checkNotNull(skill);
         }
 
@@ -26,7 +26,7 @@ public final class SkillTrigger {
         }
     }
 
-    public final String skill;
+    public final Skill skill;
     public final Conclusion conclusion;
 
     private SkillTrigger(Builder builder) {

--- a/core/src/main/java/edu/bsu/storygame/core/util/EncounterMatchingTestJson.java
+++ b/core/src/main/java/edu/bsu/storygame/core/util/EncounterMatchingTestJson.java
@@ -4,21 +4,24 @@ import edu.bsu.storygame.core.model.*;
 
 public class EncounterMatchingTestJson {
 
+    private static final Skill LOGIC = Skill.named("Logic");
+    private static final Skill MAGIC = Skill.named("Magic");
+
     public static Encounter create() {
         return Encounter.with("Cockatrice")
                 .image("pic")
                 .reaction(Reaction.create("Fight")
                         .story(Story.withText("Story 1")
-                                .trigger(SkillTrigger.skill("Logic")
+                                .trigger(SkillTrigger.skill(LOGIC)
                                         .conclusion(new Conclusion.Builder().text("Conclusion 1").points(1).build()))
-                                .trigger(SkillTrigger.skill("Magic")
-                                        .conclusion(new Conclusion.Builder().text("Conclusion 2").skill("RewardSkill").build()))
+                                .trigger(SkillTrigger.skill(MAGIC)
+                                        .conclusion(new Conclusion.Builder().text("Conclusion 2").skill(Skill.named("RewardSkill")).build()))
                                 .build()))
                 .reaction(Reaction.create("Hide")
                         .story(Story.withText("Story 2")
-                                .trigger(SkillTrigger.skill("Logic")
-                                        .conclusion(new Conclusion.Builder().text("Conclusion 1-A").points(1).skill("RewardSkill-2").build()))
-                                .trigger(SkillTrigger.skill("Magic")
+                                .trigger(SkillTrigger.skill(LOGIC)
+                                        .conclusion(new Conclusion.Builder().text("Conclusion 1-A").points(1).skill(Skill.named("RewardSkill-2")).build()))
+                                .trigger(SkillTrigger.skill(MAGIC)
                                         .conclusion(new Conclusion.Builder().text("Conclusion 2-B").build()))
                                 .build()))
                 .build();

--- a/core/src/main/java/edu/bsu/storygame/core/view/EncounterCardFactory.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/EncounterCardFactory.java
@@ -108,7 +108,7 @@ public class EncounterCardFactory {
                             final Story story = reaction.story;
                             add(new StoryLabel(story));
                             for (final SkillTrigger trigger : story.triggers) {
-                                Button skillButton = new Button(trigger.skill);
+                                Button skillButton = new SkillButton(trigger.skill);
                                 skillButton.onClick(new Slot<Button>() {
                                     @Override
                                     public void onEmit(Button button) {
@@ -149,6 +149,17 @@ public class EncounterCardFactory {
                 });
             }
 
+
+            final class SkillButton extends Button {
+                private SkillButton(Skill skill) {
+                    super(skill.name);
+                }
+
+                @Override
+                protected Class<?> getStyleClass() {
+                    return SkillButton.class;
+                }
+            }
 
             final class StoryLabel extends Label {
                 private StoryLabel(Story story) {
@@ -208,7 +219,7 @@ public class EncounterCardFactory {
                                     .append(" skill");
                         } else {
                             stringBuilder.append("You gain the ")
-                                    .append(conclusion.skill)
+                                    .append(conclusion.skill.name)
                                     .append(" skill");
                         }
                     }

--- a/core/src/main/java/edu/bsu/storygame/core/view/GameStyle.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/GameStyle.java
@@ -31,13 +31,17 @@ public final class GameStyle {
         int bgColor = 0xFFCCCCCC, ulColor = 0xFFEEEEEE, brColor = 0xFFAAAAAA;
         Background butBg = Background.roundRect(gfx, bgColor, 5, ulColor, 2).inset(5, 6, 2, 6);
         Background butSelBg = Background.roundRect(gfx, bgColor, 5, brColor, 2).inset(6, 5, 1, 7);
+
+        final Style.Binding buttonRegularStyle = Style.BACKGROUND.is(butBg);
+        final Style.Binding buttonSelectedStyle = Style.BACKGROUND.is(butSelBg);
+
         return Stylesheet.builder()
                 .add(Label.class,
                         Style.FONT.is(font))
                 .add(Button.class,
-                        Style.BACKGROUND.is(butBg))
+                        buttonRegularStyle)
                 .add(Button.class, Style.Mode.SELECTED,
-                        Style.BACKGROUND.is(butSelBg))
+                        buttonSelectedStyle)
                 .add(ToggleButton.class,
                         Style.BACKGROUND.is(butBg))
                 .add(ToggleButton.class, Style.Mode.SELECTED,
@@ -75,6 +79,10 @@ public final class GameStyle {
                         Style.COLOR.is(Colors.WHITE))
                 .add(EncounterCardFactory.EncounterCard.InteractionArea.ConclusionLabel.class,
                         Style.TEXT_WRAP.on,
-                        Style.COLOR.is(Colors.WHITE));
+                        Style.COLOR.is(Colors.WHITE))
+                .add(EncounterCardFactory.EncounterCard.InteractionArea.SkillButton.class,
+                        buttonRegularStyle)
+                .add(EncounterCardFactory.EncounterCard.InteractionArea.SkillButton.class, Style.Mode.SELECTED,
+                        buttonSelectedStyle);
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/view/GameStyle.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/GameStyle.java
@@ -80,9 +80,9 @@ public final class GameStyle {
                 .add(EncounterCardFactory.EncounterCard.InteractionArea.ConclusionLabel.class,
                         Style.TEXT_WRAP.on,
                         Style.COLOR.is(Colors.WHITE))
-                .add(EncounterCardFactory.EncounterCard.InteractionArea.SkillButton.class,
+                .add(EncounterCardFactory.EncounterCard.InteractionArea.SkillTriggerButton.class,
                         buttonRegularStyle)
-                .add(EncounterCardFactory.EncounterCard.InteractionArea.SkillButton.class, Style.Mode.SELECTED,
+                .add(EncounterCardFactory.EncounterCard.InteractionArea.SkillTriggerButton.class, Style.Mode.SELECTED,
                         buttonSelectedStyle);
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/view/PlayerCreationGroup.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/PlayerCreationGroup.java
@@ -1,6 +1,7 @@
 package edu.bsu.storygame.core.view;
 
 import edu.bsu.storygame.core.MonsterGame;
+import edu.bsu.storygame.core.model.Skill;
 import react.Slot;
 import react.Value;
 import tripleplay.ui.*;
@@ -58,9 +59,9 @@ public class PlayerCreationGroup extends Group {
     }
 
     private Group createSkillGroup() {
-        Set<String> skillSet = game.narrativeCache.state.result().get().skills();
+        Set<Skill> skillSet = game.narrativeCache.state.result().get().skills();
         Group group = new Group(new TableLayout(2).gaps(20, 20));
-        for (String skill : skillSet) {
+        for (Skill skill : skillSet) {
             group.add(new SkillButton(skill));
 
         }
@@ -77,8 +78,8 @@ public class PlayerCreationGroup extends Group {
         private static final float PERCENT_OF_HEIGHT = 0.1f;
         private static final float PERCENT_OF_WIDTH = 0.2f;
 
-        SkillButton(String text) {
-            super(text);
+        SkillButton(Skill skill) {
+            super(skill.name);
             setConstraint(Constraints.fixedSize(
                     game.bounds.width() * PERCENT_OF_WIDTH,
                     game.bounds.height() * PERCENT_OF_HEIGHT));

--- a/core/src/main/java/edu/bsu/storygame/core/view/PlayerCreationScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/PlayerCreationScreen.java
@@ -1,18 +1,19 @@
 package edu.bsu.storygame.core.view;
 
+import com.google.common.collect.Lists;
 import edu.bsu.storygame.core.MonsterGame;
 import edu.bsu.storygame.core.assets.Typeface;
 import edu.bsu.storygame.core.model.GameContext;
 import edu.bsu.storygame.core.model.Player;
+import edu.bsu.storygame.core.model.Skill;
 import playn.core.Game;
-import react.RList;
 import react.Slot;
 import tripleplay.game.ScreenStack;
 import tripleplay.ui.*;
 import tripleplay.ui.layout.AxisLayout;
 import tripleplay.util.Colors;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class PlayerCreationScreen extends ScreenStack.UIScreen {
 
@@ -77,12 +78,12 @@ public class PlayerCreationScreen extends ScreenStack.UIScreen {
 
     private GameContext createPlayerContext() {
 
-        final RList<String> skillsOne = new RList<>(new ArrayList<String>());
-        final RList<String> skillsTwo = new RList<>(new ArrayList<String>());
+        final List<Skill> skillsOne = Lists.newArrayList();
+        final List<Skill> skillsTwo = Lists.newArrayList();
 
         for (int item = 0; item < MAX_PLAYERS; item++) {
-            skillsOne.add(playerOneGroup.selector.selections().get(item).text.get());
-            skillsTwo.add(playerTwoGroup.selector.selections().get(item).text.get());
+            skillsOne.add(Skill.named(playerOneGroup.selector.selections().get(item).text.get()));
+            skillsTwo.add(Skill.named(playerTwoGroup.selector.selections().get(item).text.get()));
         }
 
         Player playerOne = new Player.Builder().name(playerOneGroup.nameField.text.get())

--- a/core/src/main/java/edu/bsu/storygame/core/view/Sidebar.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/Sidebar.java
@@ -3,6 +3,7 @@ package edu.bsu.storygame.core.view;
 import edu.bsu.storygame.core.assets.Typeface;
 import edu.bsu.storygame.core.model.GameContext;
 import edu.bsu.storygame.core.model.Player;
+import edu.bsu.storygame.core.model.Skill;
 import react.RList;
 import tripleplay.ui.Background;
 import tripleplay.ui.Group;
@@ -44,14 +45,14 @@ public class Sidebar extends Group {
         }
 
         private void watchForSkillChanges() {
-            player.skills.connect(new RList.Listener<String>() {
+            player.skills.connect(new RList.Listener<Skill>() {
                 @Override
-                public void onAdd(String elem) {
+                public void onAdd(Skill elem) {
                     regenerateSkillGroup();
                 }
 
                 @Override
-                public void onRemove(String elem) {
+                public void onRemove(Skill elem) {
                     regenerateSkillGroup();
                 }
             });
@@ -59,15 +60,15 @@ public class Sidebar extends Group {
 
         private void regenerateSkillGroup() {
             skillGroup.removeAll();
-            for (String skill : player.skills) {
+            for (Skill skill : player.skills) {
                 skillGroup.add(new SkillLabel(skill));
             }
         }
     }
 
     final class SkillLabel extends Label {
-        private SkillLabel(String skill) {
-            super(skill);
+        private SkillLabel(Skill skill) {
+            super(skill.name);
         }
 
         @Override

--- a/core/src/test/java/edu/bsu/storygame/core/model/NarrativeTest.java
+++ b/core/src/test/java/edu/bsu/storygame/core/model/NarrativeTest.java
@@ -32,7 +32,7 @@ public class NarrativeTest {
                         }))
                         .build();
 
-        Set<String> expected = ImmutableSet.of("Logic", "Magic");
+        Set<Skill> expected = ImmutableSet.of(Skill.named("Logic"), Skill.named("Magic"));
         assertEquals(expected, narrative.skills());
     }
 }

--- a/core/src/test/java/edu/bsu/storygame/core/model/PlayerTest.java
+++ b/core/src/test/java/edu/bsu/storygame/core/model/PlayerTest.java
@@ -1,11 +1,11 @@
 package edu.bsu.storygame.core.model;
 
+import com.google.common.collect.Lists;
 import com.google.common.testing.EqualsTester;
 import org.junit.Test;
-import react.RList;
 import tripleplay.util.Colors;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class PlayerTest {
 
@@ -13,7 +13,7 @@ public class PlayerTest {
     public void testEquals() {
         final String p1Name = "Player 1";
         final String p2Name = "Player 2";
-        final RList<String> skills = new RList<>(new ArrayList<String>());
+        final List<Skill> skills = Lists.newArrayList();
         Player p1 = new Player.Builder().name(p1Name)
                 .color(Colors.CYAN).skills(skills).build();
         Player p2 = new Player.Builder().name(p2Name)

--- a/core/src/test/java/edu/bsu/storygame/core/model/SkillTest.java
+++ b/core/src/test/java/edu/bsu/storygame/core/model/SkillTest.java
@@ -1,0 +1,17 @@
+package edu.bsu.storygame.core.model;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+public class SkillTest {
+
+    @Test
+    public void testEquals() {
+        new EqualsTester().addEqualityGroup(
+                Skill.named("weapon use"),
+                Skill.named("Weapon Use")
+        ).addEqualityGroup(Skill.named("magic"),
+                Skill.named("Magic"))
+                .testEquals();
+    }
+}


### PR DESCRIPTION
Previously, when the skill concept was only represented as a String, there had to be ad hoc, distributed logic to ensure that the strings were normalized---for example, to handle "weapon use" vs. "Weapon Use". By bringing the Skill class back (but not as an enum, like before), we now have one class that is clearly responsible for this normalization.