### PR TITLE
Require five points for victory

### DIFF
--- a/core/src/main/java/edu/bsu/storygame/core/KeystrokeBasedPlayerGenerator.java
+++ b/core/src/main/java/edu/bsu/storygame/core/KeystrokeBasedPlayerGenerator.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-public class DebugMode implements SignalView.Listener<Keyboard.Event> {
+public class KeystrokeBasedPlayerGenerator implements SignalView.Listener<Keyboard.Event> {
 
     private static final ImmutableList<Skill> SAMPLE_SKILLS = ImmutableList.of(
             Skill.named("Weapon use"),
@@ -46,7 +46,7 @@ public class DebugMode implements SignalView.Listener<Keyboard.Event> {
     private final MonsterGame game;
     private final ImmutableMap<Key, Runnable> actionMap = builder.build();
 
-    public DebugMode(MonsterGame game) {
+    public KeystrokeBasedPlayerGenerator(MonsterGame game) {
         this.game = checkNotNull(game);
     }
 

--- a/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
+++ b/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
@@ -21,13 +21,22 @@ public class MonsterGame extends SceneGame {
 
     private static final int UPDATE_RATE_MS = 33; // 30 times per second
 
-    public static final class Config {
+    public interface ReadableConfig {
+        boolean debugMode();
+    }
+
+    public static final class Config implements ReadableConfig {
         public Platform platform;
         public Narrative narrativeOverride;
         public boolean debugMode = false;
 
         public Config(Platform plat) {
             this.platform = checkNotNull(plat);
+        }
+
+        @Override
+        public boolean debugMode() {
+            return debugMode;
         }
     }
 
@@ -36,9 +45,11 @@ public class MonsterGame extends SceneGame {
     public final GameBounds bounds;
     public final ScreenStack screenStack;
     public final NarrativeCache narrativeCache;
+    public final ReadableConfig config;
 
     public MonsterGame(Config config) {
         super(config.platform, UPDATE_RATE_MS);
+        this.config = config;
         imageCache = new ImageCache(plat.assets());
         tileCache = new TileCache(plat.assets());
         narrativeCache =
@@ -47,7 +58,7 @@ public class MonsterGame extends SceneGame {
                         : new NarrativeCache.Overridden(config.narrativeOverride);
         initInput();
         if (config.debugMode) {
-            plat.input().keyboardEvents.connect(new DebugMode(this));
+            plat.input().keyboardEvents.connect(new KeystrokeBasedPlayerGenerator(this));
         }
         this.bounds = initAspectRatio();
         screenStack = new ScreenStack(this, rootLayer);

--- a/core/src/main/java/edu/bsu/storygame/core/model/GameContext.java
+++ b/core/src/main/java/edu/bsu/storygame/core/model/GameContext.java
@@ -14,7 +14,7 @@ public final class GameContext {
     public final ImmutableList<Player> players;
     public final Value<Player> currentPlayer;
     public final Value<Encounter> encounter = Value.create(null);
-    public final Value<Integer> winCondition = Value.create(1);
+    public final int pointsRequiredForVictory = 5;
 
     public GameContext(MonsterGame game, Player... players) {
         this.game = checkNotNull(game);

--- a/core/src/main/java/edu/bsu/storygame/core/util/DebugKeys.java
+++ b/core/src/main/java/edu/bsu/storygame/core/util/DebugKeys.java
@@ -1,0 +1,59 @@
+package edu.bsu.storygame.core.util;
+
+import com.google.common.collect.ImmutableMap;
+import edu.bsu.storygame.core.model.GameContext;
+import edu.bsu.storygame.core.model.Player;
+import playn.core.Key;
+import playn.core.Keyboard;
+import react.SignalView;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DebugKeys implements SignalView.Listener<Keyboard.Event> {
+
+    private final ImmutableMap.Builder<Key, Runnable> builder = ImmutableMap.builder();
+
+    {
+        builder.put(Key.K1, new PointAdder(0))
+                .put(Key.K2, new PointAdder(1));
+    }
+
+    private final ImmutableMap<Key, Runnable> actionMap = builder.build();
+    private final GameContext context;
+
+    public DebugKeys(GameContext context) {
+        this.context = checkNotNull(context);
+    }
+
+    @Override
+    public void onEmit(Keyboard.Event event) {
+        if (event instanceof Keyboard.KeyEvent) {
+            Keyboard.KeyEvent keyEvent = (Keyboard.KeyEvent) event;
+            if (isActionTrigger(keyEvent)) {
+                actionMap.get(keyEvent.key).run();
+            }
+        }
+    }
+
+    private boolean isActionTrigger(Keyboard.KeyEvent keyEvent) {
+        return keyEvent.down
+                && actionMap.containsKey(keyEvent.key);
+    }
+
+    private class PointAdder implements Runnable {
+        private final int playerIndex;
+
+        public PointAdder(int playerIndex) {
+            checkArgument(playerIndex >= 0);
+            this.playerIndex = playerIndex;
+        }
+
+        @Override
+        public void run() {
+            final Player player = context.players.get(playerIndex);
+            final int points = player.storyPoints.get();
+            player.storyPoints.update(points + 1);
+        }
+    }
+}

--- a/core/src/main/java/edu/bsu/storygame/core/view/SampleGameScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/SampleGameScreen.java
@@ -5,6 +5,7 @@ import edu.bsu.storygame.core.assets.TileCache;
 import edu.bsu.storygame.core.model.GameContext;
 import edu.bsu.storygame.core.model.Phase;
 import edu.bsu.storygame.core.model.Player;
+import edu.bsu.storygame.core.util.DebugKeys;
 import playn.core.Color;
 import playn.core.Game;
 import playn.scene.GroupLayer;
@@ -35,6 +36,10 @@ public class SampleGameScreen extends ScreenStack.UIScreen {
                 (game.plat.graphics().viewSize.height() - game.bounds.height()) / 2);
 
         configurePlayerAdvancementAtEndOfRound();
+
+        if (game.config.debugMode()) {
+            game.plat.input().keyboardEvents.connect(new DebugKeys(context));
+        }
     }
 
     @Override
@@ -78,7 +83,7 @@ public class SampleGameScreen extends ScreenStack.UIScreen {
             @Override
             public void onEmit(Phase phase) {
                 if (phase.equals(Phase.END_OF_ROUND)) {
-                    if (context.currentPlayer.get().storyPoints.get().equals(context.winCondition.get())) {
+                    if (currentPlayerHasEnoughPointsToWin()) {
                         context.currentPlayer.get().hasWon.update(true);
                         configureWinScreen();
                     } else {
@@ -86,6 +91,10 @@ public class SampleGameScreen extends ScreenStack.UIScreen {
                         context.phase.update(Phase.MOVEMENT);
                     }
                 }
+            }
+
+            private boolean currentPlayerHasEnoughPointsToWin() {
+                return context.currentPlayer.get().storyPoints.get() >= context.pointsRequiredForVictory;
             }
 
             private void configureWinScreen() {


### PR DESCRIPTION
Debug keys (1,2) will add points to the numbered player. The previous DebugMode has been renamed, since it only works without a game context. The new DebugKeys class is for keyboard commands in the game.

Supporting in-game debug keys required making the config accessible outside MonsterGame; a read-only interface was added to make it clear that consumers should not try to actually change the configuration. (The config is made by the platform-specific code and passed to MonsterGame.)