### PR TITLE
Use PlayN-SNAPSHOT release to fix HTML build problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_install:
 - sudo apt-get update && sudo apt-get install oracle-java8-installer
 - java -version
 script:
+- bash ./install-playn-snapshot.sh
+- mvn install
 - mvn -Phtml clean package
 - if [ "$TRAVIS_BRANCH" == "master" ]; then bash ./deploy.sh; fi
 env:

--- a/core/monsters-core.iml
+++ b/core/monsters-core.iml
@@ -10,20 +10,19 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.9.5" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-scene:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-core:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-scene:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-core:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.samskivert:pythagoras:1.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.threerings:react:1.5.2" level="project" />
-    <orderEntry type="library" name="Maven: com.threerings:tripleplay:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: com.threerings:tripleplay:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava-gwt:19.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.0.2" level="project" />
     <orderEntry type="library" name="Maven: com.google.j2objc:j2objc-annotations:0.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.google.guava:guava-testlib:19.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-java-lwjgl2:2.0-rc3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-java-base:2.0-rc3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-java-lwjgl2:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-java-base:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.googlecode.soundlibs:mp3spi:1.9.5-1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.googlecode.soundlibs:jlayer:1.0.1-1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.googlecode.soundlibs:tritonus-share:0.3.7-1" level="project" />
@@ -39,6 +38,7 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.lwjgl.lwjgl:lwjgl-platform:natives-windows:2.9.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.lwjgl.lwjgl:lwjgl-platform:natives-osx:2.9.3" level="project" />
     <orderEntry type="module" module-name="monsters-assets" scope="TEST" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/editor/editor.iml
+++ b/editor/editor.iml
@@ -13,10 +13,6 @@
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.6.1" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.mylyn.github:org.eclipse.egit.github.core:2.1.5" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.6.1" level="project" />
-    <orderEntry type="library" name="Maven: org.eclipse.mylyn.github:org.eclipse.egit.github.core:2.1.5" level="project" />
-    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.6.1" level="project" />
     <orderEntry type="library" name="Maven: com.threerings:react:1.5.2" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-java-base:2.0-rc3" level="project" />
@@ -27,8 +23,8 @@
     <orderEntry type="library" scope="TEST" name="Maven: com.googlecode.soundlibs:tritonus-share:0.3.7-1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.java-websocket:Java-WebSocket:1.3.0" level="project" />
     <orderEntry type="module" module-name="monsters-core" scope="TEST" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-scene:2.0-rc3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.threerings:tripleplay:2.0-rc3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: io.playn:playn-scene:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: com.threerings:tripleplay:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.google.guava:guava-gwt:19.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: com.google.errorprone:error_prone_annotations:2.0.2" level="project" />

--- a/html/monsters-html.iml
+++ b/html/monsters-html.iml
@@ -11,8 +11,8 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="monsters-core" />
-    <orderEntry type="library" name="Maven: io.playn:playn-scene:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: com.threerings:tripleplay:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-scene:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: com.threerings:tripleplay:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava-gwt:19.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.0.2" level="project" />
@@ -20,26 +20,26 @@
     <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
     <orderEntry type="module" module-name="monsters-core" />
     <orderEntry type="module" module-name="monsters-assets" />
-    <orderEntry type="library" name="Maven: io.playn:playn-scene:sources:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-core:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-scene:sources:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-core:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.samskivert:pythagoras:1.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.threerings:react:1.5.2" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-html:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-core:sources:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-webgl:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-webgl:sources:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-html:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-core:sources:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-webgl:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-webgl:sources:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.google.gwt:gwt-user:2.7.0" level="project" />
     <orderEntry type="library" name="Maven: javax.validation:validation-api:1.0.0.GA" level="project" />
     <orderEntry type="library" name="Maven: javax.validation:validation-api:sources:1.0.0.GA" level="project" />
     <orderEntry type="library" name="Maven: com.allen-sauer.gwt.voices:gwt-voices:3.3.2" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-html:sources:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-html:sources:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-codeserver:2.7.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.gwt:gwt-dev:2.7.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm:5.0.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-util:5.0.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-tree:5.0.3" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-commons:5.0.3" level="project" />
-    <orderEntry type="library" name="Maven: com.threerings:tripleplay:sources:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: com.threerings:tripleplay:sources:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
   </component>

--- a/install-playn-snapshot.sh
+++ b/install-playn-snapshot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Downloads and installs the current playn snapshot
+
+# Exit with nonzero exit code if anything fails
+set -e
+
+# Echo each command to facilitate debugging
+set -x
+
+# Clone the current playn repository, build it, and install it
+mkdir playn-snapshot
+cd playn-snapshot
+git clone https://github.com/playn/playn.git
+cd playn
+mvn clean install

--- a/java/monsters-java.iml
+++ b/java/monsters-java.iml
@@ -11,19 +11,19 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="monsters-core" />
-    <orderEntry type="library" name="Maven: io.playn:playn-scene:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-core:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-scene:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-core:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.samskivert:pythagoras:1.4.1" level="project" />
     <orderEntry type="library" name="Maven: com.threerings:react:1.5.2" level="project" />
-    <orderEntry type="library" name="Maven: com.threerings:tripleplay:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: com.threerings:tripleplay:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava-gwt:19.0" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.findbugs:jsr305:1.3.9" level="project" />
     <orderEntry type="library" name="Maven: com.google.errorprone:error_prone_annotations:2.0.2" level="project" />
     <orderEntry type="library" name="Maven: com.google.j2objc:j2objc-annotations:0.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.guava:guava:19.0" level="project" />
     <orderEntry type="module" module-name="monsters-assets" />
-    <orderEntry type="library" name="Maven: io.playn:playn-java-lwjgl2:2.0-rc3" level="project" />
-    <orderEntry type="library" name="Maven: io.playn:playn-java-base:2.0-rc3" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-java-lwjgl2:2.0-SNAPSHOT" level="project" />
+    <orderEntry type="library" name="Maven: io.playn:playn-java-base:2.0-SNAPSHOT" level="project" />
     <orderEntry type="library" name="Maven: com.googlecode.soundlibs:mp3spi:1.9.5-1" level="project" />
     <orderEntry type="library" name="Maven: com.googlecode.soundlibs:jlayer:1.0.1-1" level="project" />
     <orderEntry type="library" name="Maven: com.googlecode.soundlibs:tritonus-share:0.3.7-1" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <name>MonsterGame Metaproject</name>
 
     <properties>
-        <playn.version>2.0-rc3</playn.version>
+        <playn.version>2.0-SNAPSHOT</playn.version>
         <guava.version>19.0</guava.version>
     </properties>
 


### PR DESCRIPTION
Toggle buttons were broken on the HTML build due to a bug in PlayN-2.0-rc3. That bug was just fixed in their snapshot build, and by building against that, our toggle buttons work again on the Web.