### PR TITLE
Use native text input fields in HTML

### DIFF
--- a/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
+++ b/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
@@ -30,7 +30,6 @@ import playn.scene.Pointer;
 import playn.scene.SceneGame;
 import pythagoras.f.IRectangle;
 import tripleplay.game.ScreenStack;
-import tripleplay.platform.TPPlatform;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -70,12 +69,6 @@ public class MonsterGame extends SceneGame {
         this.bounds = initAspectRatio();
         screenStack = new ScreenStack(this, rootLayer);
         screenStack.push(new LoadingScreen(this, screenStack));
-
-        if (TPPlatform.instance() != null) {
-            plat.log().debug("Has native? " + TPPlatform.instance().hasNativeTextFields());
-        } else {
-            plat.log().debug("No TPPPlatform registered. Probably running on java lwjgl and popup text, which is fine.");
-        }
     }
 
     private Pointer initInput() {

--- a/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
+++ b/core/src/main/java/edu/bsu/storygame/core/MonsterGame.java
@@ -30,6 +30,7 @@ import playn.scene.Pointer;
 import playn.scene.SceneGame;
 import pythagoras.f.IRectangle;
 import tripleplay.game.ScreenStack;
+import tripleplay.platform.TPPlatform;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -69,6 +70,12 @@ public class MonsterGame extends SceneGame {
         this.bounds = initAspectRatio();
         screenStack = new ScreenStack(this, rootLayer);
         screenStack.push(new LoadingScreen(this, screenStack));
+
+        if (TPPlatform.instance() != null) {
+            plat.log().debug("Has native? " + TPPlatform.instance().hasNativeTextFields());
+        } else {
+            plat.log().debug("No TPPPlatform registered. Probably running on java lwjgl and popup text, which is fine.");
+        }
     }
 
     private Pointer initInput() {

--- a/core/src/main/java/edu/bsu/storygame/core/view/PlayerNameScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/PlayerNameScreen.java
@@ -76,6 +76,7 @@ public class PlayerNameScreen extends BoundedUIScreen {
                     checkForCompletion();
                 }
             });
+            nameFieldOne.setVisible(false);
         } else {
             group.add(nameFieldTwo = new Field()
                     .setConstraint(Constraints.fixedSize(game.bounds.width() * 0.10f, game.bounds.height() * 0.08f)));
@@ -85,6 +86,7 @@ public class PlayerNameScreen extends BoundedUIScreen {
                     checkForCompletion();
                 }
             });
+            nameFieldTwo.setVisible(false);
         }
         group.addStyles(Style.BACKGROUND.is(Background.solid(color)));
         return group;
@@ -102,4 +104,17 @@ public class PlayerNameScreen extends BoundedUIScreen {
     public Game game() {
         return game;
     }
+
+    @Override
+    public void showTransitionCompleted() {
+        nameFieldOne.setVisible(true);
+        nameFieldTwo.setVisible(true);
+    }
+
+    @Override
+    public void hideTransitionStarted() {
+        Container.removeFromParent(nameFieldOne, true);
+        Container.removeFromParent(nameFieldTwo, true);
+    }
+
 }

--- a/core/src/main/java/edu/bsu/storygame/core/view/PlayerNameScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/PlayerNameScreen.java
@@ -29,6 +29,8 @@ import tripleplay.ui.layout.FlowLayout;
 
 public class PlayerNameScreen extends BoundedUIScreen {
 
+    private static final float NAME_FIELD_WIDTH_PERCENT = 0.25f;
+    private static final float NAME_FIELD_HEIGHT_PERCENT = 0.08f;
     private final MonsterGame game;
     private final Root root;
     private Field nameFieldOne;
@@ -66,7 +68,8 @@ public class PlayerNameScreen extends BoundedUIScreen {
         if (player == 1) {
             color = Palette.PLAYER_ONE;
             group.add(nameFieldOne = new Field()
-                    .setConstraint(Constraints.fixedSize(game.bounds.width() * 0.10f, game.bounds.height() * 0.08f)));
+                    .setConstraint(Constraints.fixedSize(game.bounds.width() * NAME_FIELD_WIDTH_PERCENT,
+                            game.bounds.height() * NAME_FIELD_HEIGHT_PERCENT)));
             nameFieldOne.text.connect(new Slot<String>() {
                 @Override
                 public void onEmit(String s) {
@@ -76,7 +79,8 @@ public class PlayerNameScreen extends BoundedUIScreen {
             nameFieldOne.setVisible(false);
         } else {
             group.add(nameFieldTwo = new Field()
-                    .setConstraint(Constraints.fixedSize(game.bounds.width() * 0.10f, game.bounds.height() * 0.08f)));
+                    .setConstraint(Constraints.fixedSize(game.bounds.width() * NAME_FIELD_WIDTH_PERCENT,
+                            game.bounds.height() * NAME_FIELD_HEIGHT_PERCENT)));
             nameFieldTwo.text.connect(new Slot<String>() {
                 @Override
                 public void onEmit(String s) {

--- a/core/src/main/java/edu/bsu/storygame/core/view/PlayerNameScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/view/PlayerNameScreen.java
@@ -23,15 +23,12 @@ import edu.bsu.storygame.core.MonsterGame;
 import edu.bsu.storygame.core.assets.Typeface;
 import playn.core.Game;
 import react.Slot;
-import react.Value;
-import react.ValueView;
 import tripleplay.ui.*;
 import tripleplay.ui.layout.AxisLayout;
 import tripleplay.ui.layout.FlowLayout;
 
 public class PlayerNameScreen extends BoundedUIScreen {
 
-    public final ValueView<Boolean> complete = Value.create(false);
     private final MonsterGame game;
     private final Root root;
     private Field nameFieldOne;
@@ -94,10 +91,7 @@ public class PlayerNameScreen extends BoundedUIScreen {
 
     private void checkForCompletion() {
         final boolean isComplete = !nameFieldOne.text.get().trim().isEmpty() && !nameFieldTwo.text.get().trim().isEmpty();
-        ((Value<Boolean>) complete).update(isComplete);
-        if (complete.get()) {
-            continueButton.setEnabled(true);
-        }
+        continueButton.setEnabled(isComplete);
     }
 
     @Override

--- a/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
+++ b/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
@@ -69,33 +69,24 @@ public class HtmlNativeTextField implements NativeTextField {
 
     @Override
     public void setEnabled(boolean enabled) {
-        plat.log().debug("setEnabled: " + enabled);
         element.setPropertyBoolean("disabled", !enabled);
     }
 
     @Override
     public void focus() {
-        plat.log().debug("focus");
         element.focus();
     }
 
     // This method is called by native Javascript, so the Java compiler doesn't recognize it as used.
     @SuppressWarnings("unused")
     public static void onInput(int id) {
-        log("on input: " + id);
         HtmlNativeTextField target = map.get(id);
         String text = target.element.getPropertyString("value");
         target.field.field().text.update(text);
-        log("text is " + text);
     }
-
-    public static native void log(String message) /*-{
-      console.log(message);
-    }-*/;
 
     @Override
     public boolean insert(String text) {
-        plat.log().debug("insert: " + text);
         int selectionStart = Integer.parseInt(element.getAttribute("selectionStart"));
         int selectionEnd = Integer.parseInt(element.getAttribute("selectionEnd"));
         String originalText = element.getAttribute("value");
@@ -108,7 +99,6 @@ public class HtmlNativeTextField implements NativeTextField {
 
     @Override
     public void setBounds(IRectangle bounds) {
-        plat.log().debug("setBounds " + bounds);
         Style style = element.getStyle();
         style.setLeft(bounds.x(), Style.Unit.PX);
         style.setTop(bounds.y(), Style.Unit.PX);
@@ -118,7 +108,6 @@ public class HtmlNativeTextField implements NativeTextField {
 
     @Override
     public void add() {
-        plat.log().debug("add");
         if (!element.hasParentElement()) {
             DOM.getElementById("playn-root").insertFirst(element);
             element.focus();
@@ -127,7 +116,6 @@ public class HtmlNativeTextField implements NativeTextField {
 
     @Override
     public void remove() {
-        plat.log().debug("remove");
         element.getParentElement().removeChild(element);
         HtmlNativeTextField removedElement = map.remove(Integer.parseInt(element.getAttribute("id")));
         if (removedElement == null) {

--- a/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
+++ b/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016 Traveler's Notebook: Monster Tales project authors
+ *
+ * This file is part of Traveler's Notebook: Monster Tales
+ *
+ * Traveler's Notebook: Monster Tales is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Traveler's Notebook: Monster Tales is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Traveler's Notebook: Monster Tales.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package edu.bsu.storygame.html;
+
+import com.google.common.collect.Maps;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.DOM;
+import playn.html.HtmlPlatform;
+import pythagoras.f.IRectangle;
+import tripleplay.platform.NativeTextField;
+import tripleplay.ui.Field;
+
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class HtmlNativeTextField implements NativeTextField {
+
+    private final static Map<Integer, HtmlNativeTextField> map = Maps.newHashMap();
+
+    private static int nextId = 0;
+    private final int id = nextId++;
+    private final Field.Native field;
+    private final HtmlPlatform plat;
+    private final Element element;
+
+    static {
+        exportStaticMethod();
+    }
+
+    public static native void exportStaticMethod() /*-{
+      $wnd.onTextChange = $entry(@edu.bsu.storygame.html.HtmlNativeTextField::onInput(I));
+    }-*/;
+
+    public HtmlNativeTextField(Field.Native field, HtmlPlatform plat) {
+        this.field = checkNotNull(field);
+        this.plat = checkNotNull(plat);
+
+        this.element = DOM.createElement("input");
+        this.element.setAttribute("type", "text");
+        this.element.setAttribute("oninput", "onTextChange(" + id + ")");
+        this.element.getStyle().setPosition(Style.Position.ABSOLUTE);
+        this.element.setAttribute("id", "" + id);
+
+        map.put(id, this);
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        plat.log().debug("setEnabled: " + enabled);
+        element.setPropertyBoolean("disabled", !enabled);
+    }
+
+    @Override
+    public void focus() {
+        plat.log().debug("focus--- cannot currently handle this?");
+    }
+
+    public static void onInput(int id) {
+        log("on input: " + id);
+        HtmlNativeTextField target = map.get(id);
+        String text = target.element.getPropertyString("value");
+        target.field.field().text.update(text);
+        log("text is " + text);
+    }
+
+    public static native void log(String message) /*-{
+      console.log(message);
+    }-*/;
+
+    @Override
+    public boolean insert(String text) {
+        plat.log().debug("insert: " + text);
+        int selectionStart = Integer.parseInt(element.getAttribute("selectionStart"));
+        int selectionEnd = Integer.parseInt(element.getAttribute("selectionEnd"));
+        String originalText = element.getAttribute("value");
+        element.setAttribute("value",
+                originalText.substring(0, selectionStart)
+                        + text
+                        + originalText.substring(selectionEnd));
+        return true;
+    }
+
+    @Override
+    public void setBounds(IRectangle bounds) {
+        plat.log().debug("setBounds " + bounds);
+        Style style = element.getStyle();
+        style.setLeft(bounds.x(), Style.Unit.PX);
+        style.setTop(bounds.y(), Style.Unit.PX);
+        style.setWidth(bounds.width(), Style.Unit.PX);
+        style.setHeight(bounds.height(), Style.Unit.PX);
+    }
+
+    @Override
+    public void add() {
+        plat.log().debug("add");
+        DOM.getElementById("playn-root").insertFirst(element);
+    }
+
+    @Override
+    public void remove() {
+        plat.log().debug("remove");
+        DOM.getElementById("playn-root").removeChild(element);
+    }
+}

--- a/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
+++ b/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
@@ -37,7 +37,6 @@ public class HtmlNativeTextField implements NativeTextField {
     private final static Map<Integer, HtmlNativeTextField> map = Maps.newHashMap();
 
     private static int nextId = 0;
-    private final int id = nextId++;
     private final Field.Native field;
     private final HtmlPlatform plat;
     private final Element element;
@@ -51,6 +50,7 @@ public class HtmlNativeTextField implements NativeTextField {
     }-*/;
 
     public HtmlNativeTextField(Field.Native field, HtmlPlatform plat) {
+        final int id = nextId++;
         this.field = checkNotNull(field);
         this.plat = checkNotNull(plat);
 
@@ -71,9 +71,12 @@ public class HtmlNativeTextField implements NativeTextField {
 
     @Override
     public void focus() {
-        plat.log().debug("focus--- cannot currently handle this?");
+        plat.log().debug("focus");
+        element.focus();
     }
 
+    // This method is called by native Javascript, so the Java compiler doesn't recognize it as used.
+    @SuppressWarnings("unused")
     public static void onInput(int id) {
         log("on input: " + id);
         HtmlNativeTextField target = map.get(id);
@@ -112,12 +115,15 @@ public class HtmlNativeTextField implements NativeTextField {
     @Override
     public void add() {
         plat.log().debug("add");
-        DOM.getElementById("playn-root").insertFirst(element);
+        if (!element.hasParentElement()) {
+            DOM.getElementById("playn-root").insertFirst(element);
+            element.focus();
+        }
     }
 
     @Override
     public void remove() {
         plat.log().debug("remove");
-        DOM.getElementById("playn-root").removeChild(element);
+        element.getParentElement().removeChild(element);
     }
 }

--- a/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
+++ b/html/src/main/java/edu/bsu/storygame/html/HtmlNativeTextField.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Maps;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.DOM;
+import edu.bsu.storygame.core.assets.FontConstants;
 import playn.html.HtmlPlatform;
 import pythagoras.f.IRectangle;
 import tripleplay.platform.NativeTextField;
@@ -35,6 +36,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class HtmlNativeTextField implements NativeTextField {
 
     private final static Map<Integer, HtmlNativeTextField> map = Maps.newHashMap();
+    private static final float FONT_SIZE_PERCENT_OF_FIELD_HEIGHT = 0.75f;
 
     private static int nextId = 0;
     private final Field.Native field;
@@ -58,6 +60,8 @@ public class HtmlNativeTextField implements NativeTextField {
         this.element.setAttribute("type", "text");
         this.element.setAttribute("oninput", "onTextChange(" + id + ")");
         this.element.getStyle().setPosition(Style.Position.ABSOLUTE);
+        this.element.getStyle().setProperty("font-family", FontConstants.HANDWRITING_NAME);
+        this.element.getStyle().setFontSize(field.field().size().height() * FONT_SIZE_PERCENT_OF_FIELD_HEIGHT, Style.Unit.PX);
         this.element.setAttribute("id", "" + id);
 
         map.put(id, this);
@@ -125,5 +129,10 @@ public class HtmlNativeTextField implements NativeTextField {
     public void remove() {
         plat.log().debug("remove");
         element.getParentElement().removeChild(element);
+        HtmlNativeTextField removedElement = map.remove(Integer.parseInt(element.getAttribute("id")));
+        if (removedElement == null) {
+            plat.log().warn("Attempt to remove element not in map: " + element);
+        }
+
     }
 }

--- a/html/src/main/java/edu/bsu/storygame/html/HtmlTpPlatform.java
+++ b/html/src/main/java/edu/bsu/storygame/html/HtmlTpPlatform.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Traveler's Notebook: Monster Tales project authors
+ *
+ * This file is part of Traveler's Notebook: Monster Tales
+ *
+ * Traveler's Notebook: Monster Tales is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Traveler's Notebook: Monster Tales is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Traveler's Notebook: Monster Tales.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package edu.bsu.storygame.html;
+
+import playn.html.HtmlPlatform;
+import tripleplay.platform.NativeTextField;
+import tripleplay.platform.TPPlatform;
+import tripleplay.ui.Field;
+
+public class HtmlTpPlatform extends TPPlatform {
+
+    private final HtmlPlatform plat;
+
+    public HtmlTpPlatform(HtmlPlatform plat) {
+        this.plat = plat;
+    }
+
+    @Override
+    public boolean hasNativeTextFields() {
+        return true;
+    }
+
+    @Override
+    public NativeTextField refresh(NativeTextField previous) {
+        // TODO Check for style changes
+        return previous;
+    }
+
+    @Override
+    public NativeTextField createNativeTextField(Field.Native field) {
+        return new HtmlNativeTextField(field, plat);
+    }
+}

--- a/html/src/main/java/edu/bsu/storygame/html/MonsterGameHtml.java
+++ b/html/src/main/java/edu/bsu/storygame/html/MonsterGameHtml.java
@@ -25,6 +25,7 @@ import edu.bsu.storygame.core.MonsterGame;
 import edu.bsu.storygame.core.json.NarrativeParser;
 import playn.core.json.JsonParserException;
 import playn.html.HtmlPlatform;
+import tripleplay.platform.TPPlatform;
 
 public class MonsterGameHtml implements EntryPoint {
 
@@ -38,6 +39,13 @@ public class MonsterGameHtml implements EntryPoint {
         plat.assets().setPathPrefix("monsters/");
         MonsterGame.Config gameConf = new MonsterGame.Config(plat);
         handleNarrativeOverride(gameConf);
+
+        HtmlTpPlatform tpPlatform = new HtmlTpPlatform(plat) {
+            {
+                TPPlatform._instance = this;
+            }
+        };
+
         new MonsterGame(gameConf);
         plat.start();
     }

--- a/html/src/main/java/edu/bsu/storygame/html/MonsterGameHtml.java
+++ b/html/src/main/java/edu/bsu/storygame/html/MonsterGameHtml.java
@@ -40,7 +40,7 @@ public class MonsterGameHtml implements EntryPoint {
         MonsterGame.Config gameConf = new MonsterGame.Config(plat);
         handleNarrativeOverride(gameConf);
 
-        HtmlTpPlatform tpPlatform = new HtmlTpPlatform(plat) {
+        new HtmlTpPlatform(plat) {
             {
                 TPPlatform._instance = this;
             }


### PR DESCRIPTION
This replaces the default TriplePlay pop-up text entry method with a native HTML text input overlays. This required writing a custom Html TriplePlay platform (`HtmlTpPlatform`), since TriplePlay only provides Java (LWJGL), SWT, and iOS TPPlatform implementations--all of which are in a state of broken, incidentally, so don't use them.

The `HtmlTpPlatform` will produce an HTML text input widget and place it as an overlay on a TriplePlay `Field`. The current implementation has a little bit over overlap, where you can see the underlying `Field`, but this is a minor visual issue and doesn't seem to break any behaviors.

One complication of this approach is that the overlay is not actually "connected" to any TriplePlay `Group` or PlayN `Layer`. As a result, it is practically impossible to animate its position, such as when a screen comes into view. (It might technically be possible, by running a timer that monitors the locations of all parents, but I did not go down this route.) Hence, the technique that is used is to show the fields only when the transition to name selection screen completes, and to hide them as the exit transition starts---in part because the API made this fairly straightforward compared to the alternatives. Again, there is a little bit of visual artifacting, as the native fields disappear prior to the screen swipe, but I think this is still preferable to having to deal with a pop-up window for text entry.