### PR TITLE
Per-asset progress in loading screen

### DIFF
--- a/core/src/main/java/edu/bsu/storygame/core/LoadingScreen.java
+++ b/core/src/main/java/edu/bsu/storygame/core/LoadingScreen.java
@@ -1,20 +1,20 @@
 /*
  * Copyright 2016 Traveler's Notebook: Monster Tales project authors
  *
- * This file is part of monsters
+ * This file is part of Traveler's Notebook: Monster Tales
  *
- * monsters is free software: you can redistribute it and/or modify
+ * Traveler's Notebook: Monster Tales is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * monsters is distributed in the hope that it will be useful,
+ * Traveler's Notebook: Monster Tales is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with monsters.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Traveler's Notebook: Monster Tales.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package edu.bsu.storygame.core;
@@ -41,9 +41,11 @@ import tripleplay.util.Colors;
 import java.util.Collection;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.*;
 
 public class LoadingScreen extends ScreenStack.UIScreen {
+
+    private static final int NUMBER_OF_CACHES = 3;
 
     private final MonsterGame game;
     private Root root;
@@ -54,7 +56,7 @@ public class LoadingScreen extends ScreenStack.UIScreen {
         this.game = checkNotNull(game);
         configureProgressBar();
 
-        List<RFuture<Boolean>> futures = Lists.newArrayListWithCapacity(3);
+        List<RFuture<Boolean>> futures = Lists.newArrayListWithCapacity(NUMBER_OF_CACHES);
         futures.add(game.imageCache.state.map(new Function<ImageCache, Boolean>() {
             @Override
             public Boolean apply(ImageCache imageCache) {
@@ -100,14 +102,11 @@ public class LoadingScreen extends ScreenStack.UIScreen {
     }
 
     private void configureProgressBar() {
-        final int numberOfCaches = 3;
         final float width = this.size().width();
         final float height = this.size().height();
-        progressBar = new ProgressBar(numberOfCaches, width * 0.55f, height * 0.02f, game, ProgressBar.FillType.HORIZONTAL);
+        progressBar = new ProgressBar(NUMBER_OF_CACHES, width * 0.55f, height * 0.02f, game, ProgressBar.FillType.HORIZONTAL);
         layer.addCenterAt(progressBar, width / 2, height * 3 / 5);
     }
-
-
 
     @Override
     public Game game() {

--- a/core/src/main/java/edu/bsu/storygame/core/assets/AudioCache.java
+++ b/core/src/main/java/edu/bsu/storygame/core/assets/AudioCache.java
@@ -74,7 +74,7 @@ public class AudioCache {
     public Sound sound(AudioKey audioKey) {
         checkNotNull(audioKey);
         Sound sound = map.get(audioKey);
-        checkNotNull(sound, "Sound not cached: " + audioKey.name());
+        checkState(sound.isLoaded(), "Sound not cached: " + audioKey.name());
         return sound;
     }
 

--- a/core/src/main/java/edu/bsu/storygame/core/assets/AudioCache.java
+++ b/core/src/main/java/edu/bsu/storygame/core/assets/AudioCache.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.*;
 
 public class AudioCache {
 
@@ -54,12 +54,7 @@ public class AudioCache {
         List<RFuture<Sound>> futures = Lists.newArrayListWithCapacity(AudioKey.values().length);
         for (final AudioKey key : AudioKey.values()) {
             final Sound sound = assets.getSound(key.relativePath);
-            sound.state.onSuccess(new Slot<Sound>() {
-                @Override
-                public void onEmit(Sound sound) {
-                    map.put(key, sound);
-                }
-            });
+            map.put(key, sound);
             futures.add(sound.state);
         }
         RFuture.collect(futures).onComplete(new Slot<Try<Collection<Sound>>>() {
@@ -81,6 +76,10 @@ public class AudioCache {
         Sound sound = map.get(audioKey);
         checkNotNull(sound, "Sound not cached: " + audioKey.name());
         return sound;
+    }
+
+    public RFuture<Sound> stateOf(AudioKey key) {
+        return map.get(key).state;
     }
 
 }

--- a/core/src/main/java/edu/bsu/storygame/core/assets/ImageCache.java
+++ b/core/src/main/java/edu/bsu/storygame/core/assets/ImageCache.java
@@ -1,20 +1,20 @@
 /*
  * Copyright 2016 Traveler's Notebook: Monster Tales project authors
  *
- * This file is part of monsters
+ * This file is part of Traveler's Notebook: Monster Tales
  *
- * monsters is free software: you can redistribute it and/or modify
+ * Traveler's Notebook: Monster Tales is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * monsters is distributed in the hope that it will be useful,
+ * Traveler's Notebook: Monster Tales is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with monsters.  If not, see <http://www.gnu.org/licenses/>.
+ * along with Traveler's Notebook: Monster Tales.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 package edu.bsu.storygame.core.assets;
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.EnumMap;
 import java.util.List;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.*;
 
 public class ImageCache {
 
@@ -77,21 +77,16 @@ public class ImageCache {
         List<RFuture<Image>> futures = Lists.newArrayListWithCapacity(Key.values().length);
         for (final Key key : Key.values()) {
             final Image image = assets.getImage(key.path);
-            image.state.onSuccess(new Slot<Image>() {
-                @Override
-                public void onEmit(Image image) {
-                    map.put(key,image);
-                }
-            });
+            map.put(key, image);
             futures.add(image.state);
         }
         RFuture.collect(futures).onComplete(new Slot<Try<Collection<Image>>>() {
             @Override
             public void onEmit(Try<Collection<Image>> collectionTry) {
                 if (collectionTry.isSuccess()) {
-                    ((RPromise<ImageCache>)state).succeed(ImageCache.this);
+                    ((RPromise<ImageCache>) state).succeed(ImageCache.this);
                 } else {
-                    ((RPromise<ImageCache>)state).fail(collectionTry.getFailure());
+                    ((RPromise<ImageCache>) state).fail(collectionTry.getFailure());
                 }
             }
         });
@@ -105,5 +100,11 @@ public class ImageCache {
         Image image = map.get(key);
         checkNotNull(image, "Image not cached: " + key.name());
         return image;
+    }
+
+    public RFuture<Image> stateOf(Key key) {
+        Image image = map.get(key);
+        checkNotNull(image, "Image not found in map: " + key);
+        return image.state;
     }
 }

--- a/core/src/main/java/edu/bsu/storygame/core/assets/ImageCache.java
+++ b/core/src/main/java/edu/bsu/storygame/core/assets/ImageCache.java
@@ -98,7 +98,7 @@ public class ImageCache {
     public Image image(Key key) {
         checkNotNull(key);
         Image image = map.get(key);
-        checkNotNull(image, "Image not cached: " + key.name());
+        checkState(image.isLoaded(), "Image not cached: " + key.name());
         return image;
     }
 


### PR DESCRIPTION
This updates the loading screen's progress bar to be more fine-grained, giving feedback per asset instead of per cache.