### PR TITLE
Deploy only when not on a pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 - bash ./install-playn-snapshot.sh
 - mvn install
 - mvn -Phtml clean package
-- if [ "$TRAVIS_BRANCH" == "master" ]; then bash ./deploy.sh; fi
+- if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./deploy.sh; fi
 env:
   global:
   - GH_REF: github.com/spring-studio-2016/monsters


### PR DESCRIPTION
A build happens on master as part of the pull request process, but we don't actually want to deploy the project unless this is a non-PR build.