### PR TITLE
Revert "Deploy only when not on a pull request"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 script:
 - mvn install
 - mvn -Phtml clean package
-- if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./deploy.sh; fi
+- if [ "$TRAVIS_BRANCH" == "master" ]; then bash ./deploy.sh; fi
 env:
   global:
   - GH_REF: github.com/spring-studio-2016/monsters


### PR DESCRIPTION
Reverts spring-studio-2016/monsters#73

This didn't seem to actually fix the problem: the build run after the merge did not push a new copy of the code. Instead, the conditional statement exited with code 0, which makes me think there's an error in the expression.