### PR TITLE
Prevent scrolling and zooming

### DIFF
--- a/html/src/main/webapp/index.html
+++ b/html/src/main/webapp/index.html
@@ -35,6 +35,8 @@
             src: url(monsters/fonts/Handlee-Regular.ttf);
         }
         html,body {
+          margin: 0px;
+          overflow-y: hidden;
           width: 100%;
           height: 100%;
         }
@@ -44,8 +46,9 @@
         }
     </style>
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
     <meta name="apple-mobile-web-app-capable" content="yes"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="apple-touch-icon" href="touch-icon.png">
 
     <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
The viewport meta prevents zooming. Setting margin to 0px overrides a curious default user agent in mobile Chrome (at least), and overflow-y clips out the little bit of unused vertical space that allowed scrolling.
